### PR TITLE
Remove unneeded dependencies

### DIFF
--- a/strawberry.spec
+++ b/strawberry.spec
@@ -11,9 +11,7 @@ BuildRequires:	cmake
 BuildRequires:	cmake(qt6)
 BuildRequires:	qmake-qt6
 BuildRequires:	boost-devel
-BuildRequires:	liblastfm-devel
 BuildRequires:	pkgconfig(alsa)
-BuildRequires:	pkgconfig(cryptopp)
 BuildRequires:	pkgconfig(dbus-1)
 BuildRequires:	pkgconfig(fftw3)
 BuildRequires:	pkgconfig(glew)
@@ -21,40 +19,32 @@ BuildRequires:	pkgconfig(glu)
 BuildRequires:	pkgconfig(gstreamer-1.0)
 BuildRequires:	pkgconfig(gstreamer-plugins-base-1.0)
 BuildRequires:	pkgconfig(gstreamer-tag-1.0)
-BuildRequires:  pkgconfig(gnutls)
+BuildRequires:	pkgconfig(gnutls)
 BuildRequires:	pkgconfig(libcdio)
 BuildRequires:	pkgconfig(libchromaprint)
 BuildRequires:	pkgconfig(libgpod-1.0)
 BuildRequires:	pkgconfig(libmtp)
 BuildRequires:	pkgconfig(libplist-2.0)
-# For Google Drive integration
-BuildRequires:	pkgconfig(libsparsehash)
 BuildRequires:	pkgconfig(libusbmuxd-2.0)
 BuildRequires:	pkgconfig(libvlc)
 BuildRequires:	pkgconfig(protobuf) >= 3.3.2
-BuildRequires:	pkgconfig(QJson)
-BuildRequires:	pkgconfig(taglib) >= 1.6
+BuildRequires:	pkgconfig(taglib) >= 1.11.1
 BuildRequires:	cmake(Qt6Concurrent)
 BuildRequires:	cmake(Qt6Core)
 BuildRequires:	cmake(Qt6DBus)
 BuildRequires:	cmake(Qt6Gui)
 BuildRequires:	cmake(Qt6Network)
-BuildRequires:	cmake(Qt6OpenGL)
 BuildRequires:	cmake(Qt6Sql)
 BuildRequires:	cmake(Qt6Widgets)
-BuildRequires:	cmake(Qt6Xml)
 BuildRequires:	cmake(Qt6Test)
-BuildRequires:  qt6-qttools
+BuildRequires:	qt6-qttools
 BuildRequires:	pkgconfig(libpulse)
-BuildRequires:	pkgconfig(libxml-2.0)
 BuildRequires:	pkgconfig(sqlite3)
 BuildRequires:	pkgconfig(xkbcommon)
 BuildRequires:	pkgconfig(vulkan)
 BuildRequires:	vulkan-headers
 
 
-Requires:	libprojectm-data
-Requires:	%{_lib}qt5sql5-sqlite
 Requires:	gstreamer-tools
 Requires:	gstreamer1.0-flac
 Requires:	gstreamer1.0-plugins-ugly
@@ -87,7 +77,7 @@ It's written in C++ using the Qt toolkit.
 %cmake \
 	-DCMAKE_BUILD_TYPE:STRING=Release \
 	-DBUILD_WERROR=OFF \
-  -DBUILD_WITH_QT6=ON
+	-DBUILD_WITH_QT6=ON
     
 %make_build
 


### PR DESCRIPTION
liblastfm - Strawberry does not use this library, it is Qt 5 and will also pull inn unneeded Qt 5 modules.
cryptopp - Strawberry have never used this.
libsparsehash - Strawberry have never used this.
QJson - Strawberry uses the Json API in Qt Core and does not depend on this. This is also Qt 5 and will pull in unnecessary dependencies. This library was mostly used prior to Qt 5 because Qt did not have Json support.
Qt6Xml - This is the old Qt Xml module. Strawberry uses the "new" XML API in the Qt Core module (QXmlStreamReader/QXmlStreamWriter).
libxml - Another Xml library strawberry does not use.
libprojectm-data - Strawberry does not use projectm.
Qt6OpenGL - Strawberry does not use this Qt module.
taglib - Strawberry won't compile with taglib 1.6, the oldest release supported is 1.11.1.

qt5sql5-sqlite - This is the Qt 5 sqlite driver plugin, for Qt 6 the driver is part of the Qt6Sql package:
```
lib64Qt6Sql6-6.2.2-3.x86_64 : Qt 6 SQL library
Repo        : @System
Matched from:
Other       : *libqsqlite.so
```

+  I changed some spaces to tabs for consistency with the rest of the file.
